### PR TITLE
Update server.php to work with php8.1

### DIFF
--- a/site/server.php
+++ b/site/server.php
@@ -162,8 +162,8 @@ if(!empty($serverlist))
 	{
 	foreach($serverlist AS $key => $value)
 		{
-		$allslots=$allslots+$value['virtualserver_maxclients'];
-		$allusedslots=$allusedslots+$value['virtualserver_clientsonline'];
+		$allslots=$allslots.$value['virtualserver_maxclients'];
+		$allusedslots=$allusedslots.$value['virtualserver_clientsonline'];
 		$conv_time=$ts3->convertSecondsToArrayTime($value['virtualserver_uptime']);
 		$serverlist[$key]['virtualserver_uptime']=$conv_time['days'].$lang['days']." ".$conv_time['hours'].$lang['hours']." ".$conv_time['minutes'].$lang['minutes']." ".$conv_time['seconds'].$lang['seconds'];
 		$serverlist[$key]=secure($serverlist[$key]);


### PR DESCRIPTION
With PHP 7.4 the ts3webinterface works fine.

In 8.1 it fails with error
`PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string + string in /site/server.php:165

PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string + string in /site/server.php:166`